### PR TITLE
Add note about changing device language to English

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -184,8 +184,8 @@ export default function Home() {
           <Alert.Title>Change device language</Alert.Title>
           <Alert.Description>
             Before starting the process, it is recommended to change the device
-            language to English. To do this, move to the "Settings" icon,
-            click "Select" button and then "Select" again until English is shown.
+            language to English. To do this, select "Settings" icon, then
+            click "OK / Confirm" button and "OK / Confirm" again until English is shown.
             Otherwise, the language will still be Chinese after flashing
             and you may not notice changes.
           </Alert.Description>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -181,6 +181,19 @@ export default function Home() {
       <Alert.Root status="info">
         <Alert.Indicator />
         <Alert.Content>
+          <Alert.Title>Change device language</Alert.Title>
+          <Alert.Description>
+            Before starting the process, it is recommended to change the device
+            language to English. To do this, move to the "Settings" icon,
+            click "Select" button and then "Select" again until English is shown.
+            Otherwise, the language will still be Chinese after flashing
+            and you may not notice changes.
+          </Alert.Description>
+        </Alert.Content>
+      </Alert.Root>
+      <Alert.Root status="info">
+        <Alert.Indicator />
+        <Alert.Content>
           <Alert.Title>Device restart instructions</Alert.Title>
           <Alert.Description>
             Once you complete a write operation, you will need to restart your


### PR DESCRIPTION
Closes #6 

The user spent a couple hours of trying to flash over and over because he still saw the Chinese language. I added a note about changing device language to English.