### PR TITLE
Add feature to identify the firmware loaded on each partition

### DIFF
--- a/src/esp/EspController.ts
+++ b/src/esp/EspController.ts
@@ -123,12 +123,8 @@ export default class EspController {
     // Optimized read for firmware identification with flexible read size and offset:
     // - Default (25KB / 0x6400): Fast path, covers 99% of cases
     // - Additional chunks: Specify offset multiples of 25KB until identification succeeds
-    //
-    // Identifier locations:
-    // - Version strings (V3.1.1, 0.12.0): 0x1A40-0x1A4C (~6.7KB)
-    // - "End of English" marker: 0x2154 (~8.5KB)
-    // - "XTOS" marker: 0x1A54 (~6.7KB)
-    // - "CrossPoint" markers: 0x1614 (~5.6KB)
+    // In testing, most firmwares are identified within the first 25KB read, so reading the entire 
+    // partition is unnecessary in the majority of cases.
 
     const baseOffset = partitionLabel === 'app0' ? 0x10000 : 0x650000;
 

--- a/src/esp/useEspOperations.ts
+++ b/src/esp/useEspOperations.ts
@@ -7,6 +7,11 @@ import {
 } from '@/remote/firmwareFetcher';
 import { downloadData } from '@/utils/download';
 import { wrapWithWakeLock } from '@/utils/wakelock';
+import {
+  identifyFirmware,
+  isIdentificationSuccessful,
+  type FirmwareInfo,
+} from '@/utils/firmwareIdentifier';
 import OtaPartition, { OtaPartitionDetails } from './OtaPartition';
 import useStepRunner from './useStepRunner';
 import EspController from './EspController';
@@ -18,10 +23,10 @@ export function useEspOperations() {
 
   const wrapWithRunning =
     <Args extends unknown[], T>(fn: (...a: Args) => Promise<T>) =>
-    async (...a: Args) => {
-      setIsRunning(true);
-      return fn(...a).finally(() => setIsRunning(false));
-    };
+      async (...a: Args) => {
+        setIsRunning(true);
+        return fn(...a).finally(() => setIsRunning(false));
+      };
 
   const flashRemoteFirmware = async (
     getFirmware: () => Promise<Uint8Array>,
@@ -374,6 +379,94 @@ export function useEspOperations() {
     );
   };
 
+  const readAndIdentifyAllFirmware = async (): Promise<{
+    app0: FirmwareInfo;
+    app1: FirmwareInfo;
+    currentBoot: 'app0' | 'app1';
+  }> => {
+    initializeSteps([
+      'Connect to device',
+      'Read otadata partition',
+      'Read app0 partition',
+      'Read app1 partition',
+      'Identify firmware types',
+      'Disconnect from device',
+    ]);
+
+    const espController = await runStep('Connect to device', async () => {
+      const c = await EspController.fromRequestedDevice();
+      await c.connect();
+      return c;
+    });
+
+    const otaPartition = await runStep('Read otadata partition', () =>
+      espController.readOtadataPartition((_, p, t) =>
+        updateStepData('Read otadata partition', {
+          progress: { current: p, total: t },
+        }),
+      ),
+    );
+
+    const currentBoot = otaPartition.getCurrentBootPartitionLabel();
+
+    const readAndIdentifyInChunks = async (partitionLabel: 'app0' | 'app1') => {
+      const chunkSize = 0x6400; // 25KB
+      const maxReadSize = 0x20000; // 128KB
+      let readData = new Uint8Array();
+      let info: FirmwareInfo | undefined;
+
+      for (let offset = 0; offset < maxReadSize; offset += chunkSize) {
+        const chunk = await espController.readAppPartitionForIdentification(
+          partitionLabel,
+          {
+            readSize: chunkSize,
+            offset,
+            onPacketReceived: (_, p, t) =>
+              updateStepData(`Read ${partitionLabel} partition`, {
+                // Show cumulative progress: offset + current chunk progress
+                // Total shows the end of current chunk range
+                progress: { current: offset + p, total: offset + t },
+              }),
+          },
+        );
+
+        const newData = new Uint8Array(readData.length + chunk.length);
+        newData.set(readData);
+        newData.set(chunk, readData.length);
+        readData = newData;
+
+        info = identifyFirmware(readData);
+        if (isIdentificationSuccessful(info)) {
+          return info;
+        }
+      }
+
+      return info ?? { type: 'unknown', version: 'unknown', displayName: 'Custom/Unknown Firmware' }; // Return the last identification result if not found
+    };
+
+    const app0Info = await runStep('Read app0 partition', () =>
+      readAndIdentifyInChunks('app0'),
+    );
+
+    const app1Info = await runStep('Read app1 partition', () =>
+      readAndIdentifyInChunks('app1'),
+    );
+
+    await runStep('Identify firmware types', async () => {
+      // This step is now just for display - identification already happened during read
+    });
+
+    await runStep('Disconnect from device', () =>
+      espController.disconnect({ skipReset: true }),
+    );
+
+    return {
+      app0: app0Info,
+      app1: app1Info,
+      currentBoot,
+    };
+  };
+
   return {
     stepData,
     isRunning,
@@ -390,6 +483,7 @@ export function useEspOperations() {
       readDebugOtadata: wrapWithRunning(readDebugOtadata),
       readAppPartition: wrapWithRunning(readAppPartition),
       swapBootPartition: wrapWithRunning(swapBootPartition),
+      readAndIdentifyAllFirmware: wrapWithRunning(readAndIdentifyAllFirmware),
     },
   };
 }

--- a/src/utils/firmwareIdentifier.ts
+++ b/src/utils/firmwareIdentifier.ts
@@ -1,0 +1,209 @@
+export interface FirmwareInfo {
+  type: 'official-english' | 'official-chinese' | 'crosspoint' | 'unknown';
+  version: string;
+  displayName: string;
+}
+
+/**
+ * Find a string in binary data and return its offset, or -1 if not found
+ */
+function findString(
+  data: Uint8Array,
+  searchString: string,
+  startOffset = 0,
+): number {
+  const encoder = new TextEncoder();
+  const searchBytes = encoder.encode(searchString);
+
+  if (data.length < searchBytes.length) {
+    return -1;
+  }
+
+  for (let i = startOffset; i <= data.length - searchBytes.length; i++) {
+    let match = true;
+    for (let j = 0; j < searchBytes.length; j++) {
+      if (data[i + j] !== searchBytes[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
+/**
+ * Validate ESP32 firmware image structure
+ */
+function isValidEsp32Image(data: Uint8Array): boolean {
+  if (data.length < 0x24) {
+    return false;
+  }
+
+  // Check ESP32 image magic byte at offset 0
+  const imageMagic = data[0];
+  if (imageMagic !== 0xe9) {
+    return false;
+  }
+
+  // Check app descriptor magic at offset 0x20
+  const view = new DataView(data.buffer, data.byteOffset);
+  const descriptorMagic = view.getUint32(0x20, true); // little-endian
+  if (descriptorMagic !== 0xabcd5432) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Extract version string from firmware binary
+ * Looks for V*.*.* pattern in official firmwares, and numeric patterns for community firmwares
+ *
+ * @param data - The firmware binary data
+ * @param searchLimit - How many bytes to search (default 25KB)
+ * @returns Version string or 'unknown' if not found
+ */
+function extractVersion(data: Uint8Array, searchLimit = 25000): string {
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  const searchArea = data.slice(0, Math.min(data.length, searchLimit));
+
+  // Try to find V-pattern versions (official firmware)
+  // Pattern: [any byte]<V3.1.1 or similar
+  for (let i = 0; i < searchArea.length - 8; i++) {
+    if (searchArea[i] === 0x56) {
+      // 'V' character
+      const chunk = decoder.decode(
+        searchArea.slice(i, Math.min(i + 10, searchArea.length)),
+      );
+      const match = chunk.match(/V\d+\.\d+\.\d+/);
+      if (match) {
+        return match[0];
+      }
+    }
+  }
+
+  // Try to find numeric versions (CrossPoint: 0.12.0, etc.)
+  try {
+    const fullString = decoder.decode(searchArea);
+
+    // Check for CrossPoint-ESP32-x.x.x pattern
+    const crossPointMatch = fullString.match(/CrossPoint-ESP32-(\d+\.\d+\.\d+)/);
+    if (crossPointMatch) {
+      return crossPointMatch[1]!;
+    }
+
+    const lines = fullString.split(/[\x00\n]/);
+    for (const line of lines) {
+      const match = line.match(/^\d+\.\d+\.\d+$/);
+      if (match) {
+        return match[0];
+      }
+    }
+
+    // Also search for version in common patterns
+    const versionMatch = fullString.match(/(?:Version[:\s]*)(\d+\.\d+\.\d+)/i);
+    if (versionMatch?.[1]) {
+      return versionMatch[1] as string;
+    }
+  } catch {
+    // Decoding failed, continue
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Identify firmware type and extract version information
+ * Uses XTOS proximity check as the sole discriminator for official firmwares
+ *
+ * Detection strategy:
+ * 1. Validate ESP32 image structure
+ * 2. Find version string (V3.x.x pattern)
+ * 3. Check what appears after the version:
+ *    - If "XTOS " appears within 50 bytes → Chinese firmware
+ *    - If no "XTOS " and valid ESP32 image → English firmware
+ * 4. Check for CrossPoint patterns
+ *
+ * @param firmwareData - The raw firmware binary data
+ * @returns FirmwareInfo object with type, version, and display name
+ */
+export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
+  // Validate it's a real ESP32 firmware image
+  const isValidImage = isValidEsp32Image(firmwareData);
+
+  // Search in first 25KB for version (official firmwares have it early)
+  const searchLimit = 25000;
+  const searchArea = firmwareData.slice(
+    0,
+    Math.min(firmwareData.length, searchLimit),
+  );
+
+  // Try to find version string
+  const version = extractVersion(searchArea);
+  const hasVersion = version !== 'unknown';
+
+  // Find version location for proximity checks (only if we found a version)
+  const versionOffset = hasVersion ? findString(searchArea, version) : -1;
+
+  // Check for official firmwares using XTOS proximity
+  if (versionOffset !== -1 && version.startsWith('V') && isValidImage) {
+    // Check area after version (next 50 bytes) for XTOS indicator
+    const areaAfterVersion = searchArea.slice(
+      versionOffset,
+      Math.min(versionOffset + 50, searchArea.length),
+    );
+
+    // Chinese firmware has "XTOS " (with trailing space) right after version
+    if (findString(areaAfterVersion, 'XTOS ') !== -1) {
+      return {
+        type: 'official-chinese',
+        version: version,
+        displayName: 'Official Chinese',
+      };
+    }
+
+    // English firmware has NO XTOS after version
+    // If we have a V-pattern version, valid ESP32 image, but no XTOS → English
+    return {
+      type: 'official-english',
+      version: version,
+      displayName: 'Official English',
+    };
+  }
+
+  // Check for CrossPoint Community firmware
+  if (
+    findString(firmwareData, 'CrossPoint-ESP32-') !== -1 ||
+    findString(firmwareData, 'Starting CrossPoint version') !== -1
+  ) {
+    // Try a deeper search for CrossPoint version
+    const cpVersion = hasVersion ? version : extractVersion(firmwareData, 100000);
+    return {
+      type: 'crosspoint',
+      version: cpVersion,
+      displayName: 'CrossPoint Community Reader',
+    };
+  }
+
+  // Unknown firmware
+  return {
+    type: 'unknown',
+    version: version,
+    displayName: 'Custom/Unknown Firmware',
+  };
+}
+
+/**
+ * Check if identification was successful (found a known firmware type)
+ * Returns false only for "unknown" firmware type
+ *
+ * @param info - The FirmwareInfo result
+ * @returns true if firmware type was identified, false if unknown
+ */
+export function isIdentificationSuccessful(info: FirmwareInfo): boolean {
+  return info.type !== 'unknown';
+}

--- a/src/utils/firmwareIdentifier.ts
+++ b/src/utils/firmwareIdentifier.ts
@@ -157,8 +157,8 @@ export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
       Math.min(versionOffset + 50, searchArea.length),
     );
 
-    // Chinese firmware has "XTOS " (with trailing space) right after version
-    if (findString(areaAfterVersion, 'XTOS ') !== -1) {
+    // Chinese firmware has "XTOS" right after version
+    if (findString(areaAfterVersion, 'XTOS') !== -1) {
       return {
         type: 'official-chinese',
         version: version,

--- a/src/utils/firmwareIdentifier.ts
+++ b/src/utils/firmwareIdentifier.ts
@@ -119,6 +119,7 @@ function extractVersion(data: Uint8Array, searchLimit = 25000): string {
 /**
  * Identify firmware type and extract version information
  * Uses XTOS proximity check as the sole discriminator for official firmwares
+ * Unfortunately, inherently brittle, due to potential changes to the official firmware.
  *
  * Detection strategy:
  * 1. Validate ESP32 image structure
@@ -135,7 +136,7 @@ export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
   // Validate it's a real ESP32 firmware image
   const isValidImage = isValidEsp32Image(firmwareData);
 
-  // Search in first 25KB for version (official firmwares have it early)
+  // Search in first 25KB for version
   const searchLimit = 25000;
   const searchArea = firmwareData.slice(
     0,
@@ -180,11 +181,9 @@ export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
     findString(firmwareData, 'CrossPoint-ESP32-') !== -1 ||
     findString(firmwareData, 'Starting CrossPoint version') !== -1
   ) {
-    // Try a deeper search for CrossPoint version
-    const cpVersion = hasVersion ? version : extractVersion(firmwareData, 100000);
     return {
       type: 'crosspoint',
-      version: cpVersion,
+      version: version,
       displayName: 'CrossPoint Community Reader',
     };
   }


### PR DESCRIPTION
(Not sure if you're taking contributions for this repo, but if you are, and think this is handy, would be happy to merge it 😁. Also fine if you don't want it, I'll just keep using it on my fork :) 👍🏻 )

Experimental feature to extract data from the partitions and attempt to identify the firmware based on common markers found in the extracted data. Tested with a number of versions of the official firmware and crosspoint. Helpful for identifying which partition contains which firmware before flashing, hopefully to prevent overwriting the wrong firmware.

Might be brittle, as changes to the firmware compilation or the source code of the firmwares may render the identification matching incorrect, requiring re-analysis of the compiled firmware to determine new pattern matching criteria.

Identified firmwares:
<img width="1608" height="1674" alt="image" src="https://github.com/user-attachments/assets/eab80d16-351c-4aeb-ae05-d81d21475c67" />

Demo video, showing identification, and swapping partitions moves the "active" label
https://github.com/user-attachments/assets/a2606e4c-86c8-445f-8dfc-12eeb6b59ac0

