### PR TITLE
Search for firmware identifier both before and after version number

### DIFF
--- a/src/utils/firmwareIdentifier.ts
+++ b/src/utils/firmwareIdentifier.ts
@@ -156,14 +156,16 @@ export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
 
   // Check for official firmwares using XTOS proximity
   if (versionOffset !== -1 && version.startsWith('V') && isValidImage) {
-    // Check area after version (next 50 bytes) for XTOS indicator
-    const areaAfterVersion = searchArea.slice(
-      versionOffset,
-      Math.min(versionOffset + 50, searchArea.length),
+    // Check area around version (50 bytes before and after) for XTOS indicator
+    const startOffset = Math.max(0, versionOffset - 50);
+    const endOffset = Math.min(
+      searchArea.length,
+      versionOffset + version.length + 50,
     );
+    const areaAroundVersion = searchArea.slice(startOffset, endOffset);
 
-    // Chinese firmware has "XTOS" right after version
-    if (findString(areaAfterVersion, 'XTOS') !== -1) {
+    // Chinese firmware has "XTOS" nearby version
+    if (findString(areaAroundVersion, 'XTOS') !== -1) {
       return {
         type: 'official-chinese',
         version,
@@ -171,7 +173,7 @@ export function identifyFirmware(firmwareData: Uint8Array): FirmwareInfo {
       };
     }
 
-    // English firmware has NO XTOS after version
+    // English firmware has NO XTOS around version
     // If we have a V-pattern version, valid ESP32 image, but no XTOS → English
     return {
       type: 'official-english',


### PR DESCRIPTION
3.1.9 has the "XTOS" identifier before the version number in the firmware, where as 3.1.7 and 3.1.8 both had it after (when I was developing the feature). Hopefully searching before and after the version number will be a little more resiliant to future changes

Currently showing v3.1.9 as the english firmware (incorrect):
<img width="399" height="291" alt="image" src="https://github.com/user-attachments/assets/9116eb84-08bd-4289-9fe0-fa2c8bf37606" />

The firmware in the browser, showing the moved XTOS from previous versions
<img width="196" height="107" alt="image" src="https://github.com/user-attachments/assets/ce0e7cd0-991c-4933-99c4-0325222e42b2" />

After the fix, showing v3.1.9 as the chinese firmware (correct):
<img width="405" height="270" alt="image" src="https://github.com/user-attachments/assets/3ae092d0-87da-480a-a4ce-fd8298cd04dc" />

